### PR TITLE
Create Submitted Response Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+rendered
+tmp
+.idea
+.terraform
+terraform.tfstate
+terraform.tfstate.backup
+terraform.tfvars
+*.pem
+
+*.zip
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # eq-terraform-dynamodb
+
+Terraform project that creates the DynamoDB infrastructure for the EQ Survey-Runner
+
+To import this module add the following code into you Terraform project:
+
+```
+module "survey-runner-dynamodb" {
+  source                             = "github.com/ONSdigital/eq-terraform-dynamodb"
+  env                                = "${var.env}"
+  aws_access_key                     = "${var.aws_access_key}"
+  aws_secret_key                     = "${var.aws_secret_key}"
+  submitted_responses_read_capacity  = 1
+  submitted_responses_write_capacity = 1
+}
+```
+
+To run this module on its own run the following code: (Replacing 'XXX' with your values)
+
+```
+terraform apply -var "env=XXX" \
+                -var "aws_access_key=XXX" \
+                -var "aws_secret_key=XXX" \
+                -var "submitted_responses_read_capacity=XXX" \
+                -var "submitted_responses_write_capacity=XXX"
+```

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  access_key = "${var.aws_access_key}"
+  secret_key = "${var.aws_secret_key}"
+  region     = "eu-west-1"
+}

--- a/global_vars.tf
+++ b/global_vars.tf
@@ -1,0 +1,21 @@
+variable "env" {
+  description = "The environment you wish to use"
+}
+
+variable "aws_secret_key" {
+  description = "Amazon Web Service Secret Key"
+}
+
+variable "aws_access_key" {
+  description = "Amazon Web Service Access Key"
+}
+
+variable "submitted_responses_read_capacity" {
+  description = "The number of Read units for the Submitted Responses table"
+  default     = 25
+}
+
+variable "submitted_responses_write_capacity" {
+  description = "The number of Write units for the Submitted Responses table"
+  default     = 25
+}

--- a/submittedResponses.tf
+++ b/submittedResponses.tf
@@ -1,0 +1,21 @@
+resource "aws_dynamodb_table" "submitted-responses-table" {
+  name           = "${var.env}-submitted-responses"
+  read_capacity  = "${var.submitted_responses_read_capacity}"
+  write_capacity = "${var.submitted_responses_write_capacity}"
+  hash_key       = "tx_id"
+
+  attribute {
+    name = "tx_id"
+    type = "S"
+  }
+
+  ttl {
+    attribute_name = "valid_until"
+    enabled        = true
+  }
+
+  tags {
+    Name        = "${var.env}-submitted-responses"
+    Environment = "${var.env}"
+  }
+}


### PR DESCRIPTION
Creates the dynamoDB table {ENV}-SubmittedResponses in AWS.

To run add the following to the survey-runner.tf file in eq-terraform.

```
module "survey-runner-dynamodb" {
  source = "github.com/ONSdigital/eq-terraform-dynamodb?ref=create-submitted-response-table"
  env                                = "${var.env}"
  aws_access_key                     = "${var.aws_access_key}"
  aws_secret_key                     = "${var.aws_secret_key}"
  submitted_responses_read_capacity  = 1
  submitted_responses_write_capacity = 1
}
```