### PR TITLE
Lock terraform AWS provider version

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -2,4 +2,5 @@ provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "eu-west-1"
+  version    = "1.1"
 }


### PR DESCRIPTION
This terraform was failing to deploy on PreProd because it was loading a version of the provider that was too new.

We should lock back these versions to be sure what versions of code are running.