### PR TITLE
Removed Locked terraform AWS provider version

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -2,5 +2,4 @@ provider "aws" {
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "eu-west-1"
-  version    = "1.1"
 }


### PR DESCRIPTION
This was causing all modules to use provider version 1.1.
Therefore not allowing us to use any new features.