### PR TITLE
Output the full ARN of the table

### DIFF
--- a/submitted_responses.tf
+++ b/submitted_responses.tf
@@ -23,3 +23,7 @@ resource "aws_dynamodb_table" "submitted_responses_table" {
 output "submitted_responses_table_name" {
   value = "${aws_dynamodb_table.submitted_responses_table.name}"
 }
+
+output "submitted_responses_table_arn" {
+  value = "${aws_dynamodb_table.submitted_responses_table.arn}"
+}


### PR DESCRIPTION
 - This means we don't need to lookup the account id and region