### PR TITLE
Specify a min AWS provider version required for point_in_time_recovery

### DIFF
--- a/aws.tf
+++ b/aws.tf
@@ -7,6 +7,8 @@ terraform {
 }
 
 provider "aws" {
+  version    = ">= 1.17.0"
+
   access_key = "${var.aws_access_key}"
   secret_key = "${var.aws_secret_key}"
   region     = "eu-west-1"


### PR DESCRIPTION
DynamoDB point in time recover is only available since `1.17.0`