### PR TITLE
Add TTL to eq session

### DIFF
--- a/eq_session.tf
+++ b/eq_session.tf
@@ -9,6 +9,11 @@ resource "aws_dynamodb_table" "eq_session_table" {
     type = "S"
   }
 
+  ttl {
+    attribute_name = "expires_at"
+    enabled        = true
+  }
+
   tags {
     Name        = "${var.env}-eq-session"
     Environment = "${var.env}"


### PR DESCRIPTION
Enables time to live attribute for the eq-session table. Automatically deletes expired session data from DB.

---
TTL compares the current time in epoch time format to the time stored in the Time To Live attribute of an item. If the epoch time value stored in the attribute is less than the current time, the item is marked as expired and subsequently deleted. This processing takes place automatically in the background and does not affect read or write traffic to the table.

DynamoDB typically deletes expired items within 48 hours of expiration.
More info: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/TTL.html

---
Should be tested with runner branch.